### PR TITLE
Add 1976 US Standard Atmosphere Model

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2924,7 +2924,8 @@ class AutoTestCopter(AutoTest):
 
         minimum_duration = 5
 
-        self.takeoff(500, timeout=60)
+        # FIXME AND LOWER back to 60 seconds once atmosphere model handles local temperature
+        self.takeoff(500, timeout=70)
         self.change_mode('AUTO')
 
         start_speed_ms = self.get_parameter('WPNAV_SPEED_DN') / 100.0

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1407,7 +1407,7 @@ class AutoTestPlane(AutoTest):
                                       0) # flags
         self.delay_sim_time(1)
 
-        return_radius = 100
+        return_radius = 90
         return_alt = 80
         self.set_parameter("RTL_RADIUS", return_radius)
         self.set_parameter("FENCE_ACTION", 6) # Set Fence Action to Guided

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -730,6 +730,9 @@ private:
 
     TriState terrainHgtStableState = TriState::UNKNOWN;
 
+    // EAS to TAS calculated on each loop
+    float _EAS2TAS{1};
+
     /*
      * private AOA and SSA-related state and methods
      */

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -135,7 +135,8 @@ public:
     // get apparent to true airspeed ratio
     float get_EAS2TAS(void) const {
         // FIXME: make this is a method on the active backend
-        return dcm.get_EAS2TAS();
+        // return dcm.get_EAS2TAS();
+        return _EAS2TAS;
     }
 
     // return an airspeed estimate if available. return true

--- a/libraries/AP_AHRS/AP_AHRS_Backend.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.cpp
@@ -198,6 +198,9 @@ void AP_AHRS::update_trig(void)
     calc_trig(get_rotation_body_to_ned(),
               _cos_roll, _cos_pitch, _cos_yaw,
               _sin_roll, _sin_pitch, _sin_yaw);
+
+    // update EAS2TAS cache
+    _EAS2TAS = AP::baro().get_EAS2TAS();
 }
 
 /*
@@ -316,8 +319,8 @@ void AP_AHRS::Log_Write_Home_And_Origin()
 }
 
 // get apparent to true airspeed ratio
-float AP_AHRS_Backend::get_EAS2TAS(void) const {
-    return AP::baro().get_EAS2TAS();
+float AP_AHRS::get_EAS2TAS(void) const {
+    return _EAS2TAS;
 }
 
 // return current vibration vector for primary IMU

--- a/libraries/AP_AHRS/AP_AHRS_Backend.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.cpp
@@ -319,8 +319,9 @@ void AP_AHRS::Log_Write_Home_And_Origin()
 }
 
 // get apparent to true airspeed ratio
-float AP_AHRS::get_EAS2TAS(void) const {
-    return _EAS2TAS;
+float AP_AHRS_Backend::get_EAS2TAS(void) const {
+    // FIXME the rebase here is convoluted.....
+    return AP::baro().get_EAS2TAS();
 }
 
 // return current vibration vector for primary IMU

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -320,5 +320,4 @@ public:
     // Set to true if the terrain underneath is stable enough to be used as a height reference
     // this is not related to terrain following
     virtual void set_terrain_hgt_stable(bool stable) {}
-
 };

--- a/libraries/AP_Airspeed/Airspeed_Calibration.cpp
+++ b/libraries/AP_Airspeed/Airspeed_Calibration.cpp
@@ -9,7 +9,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS.h>
-#include <AP_Baro/AP_Baro.h>
+#include <AP_AHRS/AP_AHRS.h>
 
 #include "AP_Airspeed.h"
 
@@ -129,7 +129,7 @@ void AP_Airspeed::update_calibration(uint8_t i, const Vector3f &vground, int16_t
 
     // calculate true airspeed, assuming a airspeed ratio of 1.0
     float dpress = MAX(get_differential_pressure(), 0);
-    float true_airspeed = sqrtf(dpress) * AP::baro().get_EAS2TAS();
+    float true_airspeed = sqrtf(dpress) * AP::ahrs().get_EAS2TAS();
 
     float zratio = state[i].calibration.update(true_airspeed, vground, max_airspeed_allowed_during_cal);
 
@@ -174,7 +174,7 @@ void AP_Airspeed::send_airspeed_calibration(const Vector3f &vground)
         vy: vground.y,
         vz: vground.z,
         diff_pressure: get_differential_pressure(primary),
-        EAS2TAS: AP::baro().get_EAS2TAS(),
+        EAS2TAS: AP::ahrs().get_EAS2TAS(),
         ratio: param[primary].ratio.get(),
         state_x: state[primary].calibration.state.x,
         state_y: state[primary].calibration.state.y,

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -365,54 +365,6 @@ void AP_Baro::update_calibration()
 
     // always update the guessed ground temp
     _guessed_ground_temperature = get_external_temperature();
-
-    // force EAS2TAS to recalculate
-    _EAS2TAS = 0;
-}
-
-// return altitude difference in meters between current pressure and a
-// given base_pressure in Pascal
-float AP_Baro::get_altitude_difference(float base_pressure, float pressure) const
-{
-    float ret;
-    float temp    = get_ground_temperature() + C_TO_KELVIN;
-    float scaling = pressure / base_pressure;
-
-    // This is an exact calculation that is within +-2.5m of the standard
-    // atmosphere tables in the troposphere (up to 11,000 m amsl).
-    ret = 153.8462f * temp * (1.0f - expf(0.190259f * logf(scaling)));
-
-    return ret;
-}
-
-
-// return current scale factor that converts from equivalent to true airspeed
-// valid for altitudes up to 10km AMSL
-// assumes standard atmosphere lapse rate
-float AP_Baro::get_EAS2TAS(void)
-{
-    float altitude = get_altitude();
-    if ((fabsf(altitude - _last_altitude_EAS2TAS) < 25.0f) && !is_zero(_EAS2TAS)) {
-        // not enough change to require re-calculating
-        return _EAS2TAS;
-    }
-
-    float pressure = get_pressure();
-    if (is_zero(pressure)) {
-        return 1.0f;
-    }
-
-    // only estimate lapse rate for the difference from the ground location
-    // provides a more consistent reading then trying to estimate a complete
-    // ISA model atmosphere
-    float tempK = get_ground_temperature() + C_TO_KELVIN - ISA_LAPSE_RATE * altitude;
-    const float eas2tas_squared = SSL_AIR_DENSITY / (pressure / (ISA_GAS_CONSTANT * tempK));
-    if (!is_positive(eas2tas_squared)) {
-        return 1.0f;
-    }
-    _EAS2TAS = sqrtf(eas2tas_squared);
-    _last_altitude_EAS2TAS = altitude;
-    return _EAS2TAS;
 }
 
 // return air density / sea level density - decreases as altitude climbs

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -107,6 +107,22 @@ public:
     // returns which i2c bus is considered "the" external bus
     uint8_t external_bus() const { return _ext_bus; }
 
+    // Atmospheric Model Functions
+    static float geometric_alt_to_geopotential(float alt);
+    static float geopotential_alt_to_geometric(float alt);
+
+    float get_temperature_from_altitude(float alt) const;
+    float get_altitude_from_pressure(float pressure) const;
+
+    // EAS2TAS for SITL
+    static float get_EAS2TAS_for_alt_amsl(float alt_amsl);
+
+    // lookup expected pressure for a given altitude. Used for SITL backend
+    static void get_pressure_temperature_for_alt_amsl(float alt_amsl, float &pressure, float &temperature_K);
+
+    // get air density for SITL
+    static float get_air_density_for_alt_amsl(float alt_amsl);
+
     // get altitude difference in meters relative given a base
     // pressure in Pascal
     float get_altitude_difference(float base_pressure, float pressure) const;
@@ -114,14 +130,8 @@ public:
     // get scale factor required to convert equivalent to true
     // airspeed. This should only be used to update the AHRS value
     // once per loop. Please use AP::ahrs().get_EAS2TAS()
-    float get_EAS2TAS(void);
+    float get_EAS2TAS(void) const;
 
-    // EAS2TAS for SITL
-    static float get_EAS2TAS_for_alt_amsl(float alt_amsl);
-
-    // get air densityfor SITL
-    static float get_air_density_for_alt_amsl(float alt_amsl);
-    
     // get air density / sea level density - decreases as altitude climbs
     float get_air_density_ratio(void);
 
@@ -199,9 +209,6 @@ public:
 #if HAL_EXTERNAL_AHRS_ENABLED
     void handle_external(const AP_ExternalAHRS::baro_data_message_t &pkt);
 #endif
-    
-    // lookup expected pressure for a given altitude. Used for SITL backend
-    static void get_pressure_temperature_for_alt_amsl(float alt_amsl, float &pressure, float &temperature_K);
 
 private:
     // singleton
@@ -305,12 +312,14 @@ private:
     // Logging function
     void Write_Baro(void);
     void Write_Baro_instance(uint64_t time_us, uint8_t baro_instance);
-    
-    // two different atomspheric models
-    float get_altitude_difference_function(float base_pressure, float pressure) const;
-    float get_altitude_difference_table(float base_pressure, float pressure) const;
-    float get_EAS2TAS_table(float pressure);
-    float get_EAS2TAS_function(float altitude, float pressure);
+
+    // atmosphere model functions
+    float get_altitude_difference_extended(float base_pressure, float pressure) const;
+    float get_EAS2TAS_extended(float pressure) const;
+    static float get_temperature_by_altitude_layer(float alt, int8_t idx);
+
+    float get_altitude_difference_simple(float base_pressure, float pressure) const;
+    float get_EAS2TAS_simple(float altitude, float pressure) const;
 };
 
 namespace AP {

--- a/libraries/AP_Baro/AP_Baro_HIL.cpp
+++ b/libraries/AP_Baro/AP_Baro_HIL.cpp
@@ -7,33 +7,6 @@ extern const AP_HAL::HAL& hal;
 // ==========================================================================
 // based on tables.cpp from http://www.pdas.com/atmosdownload.html
 
-/* 
-   Compute the temperature, density, and pressure in the standard atmosphere
-   Correct to 20 km.  Only approximate thereafter.
-*/
-void AP_Baro::SimpleAtmosphere(
-	const float alt,                           // geometric altitude, km.
-	float& sigma,                   // density/sea-level standard density
-	float& delta,                 // pressure/sea-level standard pressure
-	float& theta)           // temperature/sea-level standard temperature
-{
-    const float REARTH = 6369.0f;        // radius of the Earth (km)
-    const float GMR    = 34.163195f;     // gas constant
-    float h=alt*REARTH/(alt+REARTH);     // geometric to geopotential altitude
-
-    if (h < 11.0f) {
-        // Troposphere
-        theta = (SSL_AIR_TEMPERATURE - 6.5f * h) / SSL_AIR_TEMPERATURE;
-        delta = powf(theta, GMR / 6.5f);
-    } else {
-        // Stratosphere
-        theta = 216.65f / SSL_AIR_TEMPERATURE;
-        delta = 0.2233611f * expf(-GMR * (h - 11.0f) / 216.65f);
-    }
-
-    sigma = delta/theta;
-}
-
 void AP_Baro::SimpleUnderWaterAtmosphere(
 	float alt,            // depth, km.
 	float& rho,           // density/sea-level

--- a/libraries/AP_Baro/AP_Baro_SITL.cpp
+++ b/libraries/AP_Baro/AP_Baro_SITL.cpp
@@ -114,12 +114,9 @@ void AP_Baro_SITL::_timer()
     }
 
 #if !APM_BUILD_TYPE(APM_BUILD_ArduSub)
-    float sigma, delta, theta;
-
-    AP_Baro::SimpleAtmosphere(sim_alt * 0.001f, sigma, delta, theta);
-    float p = SSL_AIR_PRESSURE * delta;
-    float T = SSL_AIR_TEMPERATURE * theta - C_TO_KELVIN;
-
+    float p, T;
+    AP_Baro::get_pressure_temperature_for_alt_amsl(sim_alt, p, T);
+    T -= C_TO_KELVIN;
     temperature_adjustment(p, T);
 #else
     float rho, delta, theta;

--- a/libraries/AP_Baro/AP_Baro_atmosphere.cpp
+++ b/libraries/AP_Baro/AP_Baro_atmosphere.cpp
@@ -1,0 +1,389 @@
+#include "AP_Baro.h"
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  atmospheric model options
+ */
+
+#ifndef HAL_BARO_ATMOSPHERIC_TABLE
+// default to using tables when doing double precision EKF (which implies more flash space and faster MCU)
+// this allows for non-table testing with --ekf-single configure option
+#define HAL_BARO_ATMOSPHERIC_TABLE HAL_WITH_EKF_DOUBLE
+#endif
+
+/*
+  return altitude difference in meters between current pressure and a
+  given base_pressure in Pascal. This is a simple atmospheric model
+  good to about 11km AMSL. Enable the table based function for higher altitudes
+*/
+float AP_Baro::get_altitude_difference_function(float base_pressure, float pressure) const
+{
+    float ret;
+    float temp    = get_ground_temperature() + C_TO_KELVIN;
+    float scaling = pressure / base_pressure;
+
+    // This is an exact calculation that is within +-2.5m of the standard
+    // atmosphere tables in the troposphere (up to 11,000 m amsl).
+    ret = 153.8462f * temp * (1.0f - expf(0.190259f * logf(scaling)));
+
+    return ret;
+}
+
+#if HAL_BARO_ATMOSPHERIC_TABLE || CONFIG_HAL_BOARD == HAL_BOARD_SITL
+/*
+  MIL-STD 3013 (1962 U.S. Standard Atmosphere) in Tabular Form.
+
+  Using this table is more accurate over a much wider range of
+  altitudes than using the function
+ */
+static const struct {
+    float amsl_feet;
+    float temp_K;
+    float pressure_Pa;
+    float density;
+} atmospheric_table[] = {
+    { -15000, 317.9, 169732.9, 1.86000},
+    { -14000, 315.9, 164245.9, 1.81156},
+    { -13000, 313.9, 158903.4, 1.76363},
+    { -12000, 311.9, 153702.6, 1.71673},
+    { -11000, 309.9, 148640.3, 1.67086},
+    { -10000, 308.0, 143714.4, 1.62550},
+    { -9000, 306.0, 138921.1, 1.58170},
+    { -8000, 304.0, 134258.0, 1.53841},
+    { -7000, 302.0, 129722.3, 1.49614},
+    { -6000, 300.0, 125311.6, 1.45491},
+    { -5000, 298.1, 121023.5, 1.41471},
+    { -4000, 296.1, 116854.5, 1.37503},
+    { -3000, 294.1, 112802.9, 1.33638},
+    { -2000, 292.1, 108865.7, 1.29824},
+    { -1000, 290.1, 105040.6, 1.26113},
+    { 0, 288.2, 101325.1, 1.22506},
+    { 1000, 286.2, 97716.8, 1.18949},
+    { 2000, 284.2, 94212.9, 1.15496},
+    { 3000, 282.2, 90811.5, 1.12095},
+    { 4000, 280.2, 87510.7, 1.08796},
+    { 5000, 278.2, 84307.5, 1.05550},
+    { 6000, 276.3, 81199.6, 1.02406},
+    { 7000, 274.3, 78185.5, 0.99313},
+    { 8000, 272.3, 75262.4, 0.96273},
+    { 9000, 270.3, 72428.4, 0.93335},
+    { 10000, 268.3, 69681.5, 0.90449},
+    { 11000, 266.4, 67019.8, 0.87666},
+    { 12000, 264.4, 64440.5, 0.84934},
+    { 13000, 262.4, 61942.6, 0.82254},
+    { 14000, 260.4, 59523.7, 0.79626},
+    { 15000, 258.4, 57181.9, 0.77101},
+    { 16000, 256.5, 54915.2, 0.74575},
+    { 17000, 254.5, 52721.9, 0.72153},
+    { 18000, 252.5, 50599.8, 0.69834},
+    { 19000, 250.5, 48547.7, 0.67515},
+    { 20000, 248.5, 46563.0, 0.65247},
+    { 21000, 246.5, 44644.9, 0.63082},
+    { 22000, 244.6, 42791.5, 0.60969},
+    { 23000, 242.6, 41000.3, 0.58856},
+    { 24000, 240.6, 39270.9, 0.56846},
+    { 25000, 238.6, 37600.8, 0.54888},
+    { 26000, 236.6, 35988.7, 0.52981},
+    { 27000, 234.7, 34433.1, 0.51120},
+    { 28000, 232.7, 32932.0, 0.49306},
+    { 29000, 230.7, 31484.6, 0.47544},
+    { 31000, 226.7, 28744.4, 0.44163},
+    { 32000, 224.8, 27448.8, 0.42545},
+    { 33000, 222.8, 26200.5, 0.40973},
+    { 34000, 220.8, 24998.7, 0.39442},
+    { 35000, 218.8, 23841.9, 0.37958},
+    { 36000, 216.8, 22729.2, 0.36520},
+    { 36089, 216.7, 22632.0, 0.36391},
+    { 37000, 216.7, 21662.4, 0.34834},
+    { 38000, 216.7, 20645.9, 0.33201},
+    { 39000, 216.7, 19677.3, 0.31639},
+    { 40000, 216.7, 18753.7, 0.30155},
+    { 41000, 216.7, 17873.7, 0.28743},
+    { 42000, 216.7, 17034.8, 0.27392},
+    { 43000, 216.7, 16235.7, 0.26109},
+    { 44000, 216.7, 15473.9, 0.24882},
+    { 45000, 216.7, 14747.6, 0.23713},
+    { 46000, 216.7, 14055.7, 0.22599},
+    { 47000, 216.7, 13395.9, 0.21543},
+    { 48000, 216.7, 12767.3, 0.20528},
+    { 49000, 216.7, 12168.3, 0.19564},
+    { 50000, 216.7, 11597.1, 0.18646},
+    { 51000, 216.7, 11053.1, 0.17775},
+    { 52000, 216.7, 10534.1, 0.16941},
+    { 53000, 216.7, 10040.0, 0.16142},
+    { 54000, 216.7, 9568.9, 0.15384},
+    { 55000, 216.7, 9119.7, 0.14663},
+    { 56000, 216.7, 8691.7, 0.13977},
+    { 57000, 216.7, 8283.8, 0.13323},
+    { 58000, 216.7, 7895.0, 0.12694},
+    { 59000, 216.7, 7524.9, 0.12101},
+    { 60000, 216.7, 7171.5, 0.11534},
+    { 61000, 216.7, 6834.9, 0.10993},
+    { 62000, 216.7, 6514.1, 0.10472},
+    { 63000, 216.7, 6208.6, 0.09983},
+    { 64000, 216.7, 5917.0, 0.09514},
+    { 65000, 216.7, 5639.3, 0.09071},
+    { 65617, 216.7, 5474.6, 0.08803},
+    { 66000, 216.8, 5375.0, 0.08638},
+    { 67000, 217.1, 5123.2, 0.08220},
+    { 68000, 217.4, 4883.3, 0.07823},
+    { 69000, 217.7, 4654.9, 0.07447},
+    { 70000, 218.0, 4437.5, 0.07092},
+    { 71000, 218.3, 4230.7, 0.06751},
+    { 72000, 218.6, 4033.9, 0.06427},
+    { 73000, 218.9, 3846.2, 0.06123},
+    { 74000, 219.2, 3667.6, 0.05829},
+    { 76000, 219.8, 3335.8, 0.05288},
+    { 77000, 220.1, 3181.6, 0.05035},
+    { 78000, 220.4, 3034.6, 0.04796},
+    { 79000, 220.7, 2894.8, 0.04569},
+    { 80000, 221.0, 2761.3, 0.04352},
+    { 81000, 221.3, 2634.4, 0.04146},
+    { 82000, 221.6, 2513.2, 0.03950},
+    { 83000, 222.0, 2398.3, 0.03764},
+    { 84000, 222.3, 2288.2, 0.03587},
+    { 85000, 222.6, 2183.8, 0.03418},
+    { 86000, 222.9, 2083.7, 0.03258},
+    { 87000, 223.2, 1988.9, 0.03105},
+    { 88000, 223.5, 1898.5, 0.02959},
+    { 89000, 223.8, 1811.8, 0.02821},
+    { 90000, 224.1, 1729.4, 0.02689},
+    { 91000, 224.4, 1650.9, 0.02563},
+    { 92000, 224.7, 1576.2, 0.02444},
+    { 93000, 225.0, 1504.9, 0.02330},
+    { 94000, 225.3, 1436.9, 0.02222},
+    { 95000, 225.6, 1372.2, 0.02119},
+    { 96000, 225.9, 1310.0, 0.02020},
+    { 97000, 226.2, 1251.1, 0.01927},
+    { 98000, 226.5, 1195.1, 0.01838},
+    { 99000, 226.8, 1141.5, 0.01753},
+    { 100000, 227.1, 1090.2, 0.01672},
+    { 105000, 228.7, 867.6, 0.01321},
+    { 110000, 232.9, 692.3, 0.01035},
+    { 115000, 237.2, 554.9, 0.00815},
+    { 120000, 241.5, 446.2, 0.00644},
+    { 125000, 245.7, 360.5, 0.00511},
+    { 130000, 250.0, 292.1, 0.00407},
+    { 135000, 254.3, 237.5, 0.00326},
+    { 140000, 258.5, 193.9, 0.00261},
+    { 145000, 262.8, 159.0, 0.00211},
+    { 150000, 267.1, 130.7, 0.00170},
+};
+
+/*
+  find table entry given pressure. This returns at least 1
+ */
+static uint32_t lookup_atmospheric_table_by_pressure(float pressure)
+{
+    const uint32_t table_size = ARRAY_SIZE(atmospheric_table);
+    uint32_t idx_min = 1;
+    uint32_t idx_max = table_size-1;
+    if (pressure > atmospheric_table[0].pressure_Pa) {
+        // off the bottom of the table
+        idx_max = 1;
+    }
+    while (idx_min < idx_max) {
+        const uint32_t mid = (idx_max+idx_min)/2;
+        if (atmospheric_table[mid].pressure_Pa < pressure) {
+            idx_max = mid;
+        } else {
+            idx_min = mid+1;
+        }
+    }
+    return idx_min;
+}
+
+/*
+  find table entry given altitude in meters. This returns at least 1
+ */
+static uint32_t lookup_atmospheric_table_by_alt(float alt_m)
+{
+    const uint32_t table_size = ARRAY_SIZE(atmospheric_table);
+    uint32_t idx_min = 1;
+    uint32_t idx_max = table_size-1;
+    float alt_feet = alt_m / FEET_TO_METERS;
+    if (alt_feet <= atmospheric_table[0].amsl_feet) {
+        // off the bottom of the table
+        idx_max = 1;
+    }
+    while (idx_min < idx_max) {
+        const uint32_t mid = (idx_max+idx_min)/2;
+        if (atmospheric_table[mid].amsl_feet > alt_feet) {
+            idx_max = mid;
+        } else {
+            idx_min = mid+1;
+        }
+    }
+    return idx_min;
+}
+
+/*
+  return an interpolated altitude in meters given a pressure
+ */
+static float lookup_atmospheric_table_alt(const float pressure)
+{
+    uint32_t idx = lookup_atmospheric_table_by_pressure(pressure);
+    const float slope =
+        (atmospheric_table[idx].amsl_feet - atmospheric_table[idx-1].amsl_feet) /
+        (atmospheric_table[idx-1].pressure_Pa - atmospheric_table[idx].pressure_Pa);
+    const float feet = atmospheric_table[idx-1].amsl_feet - slope * (pressure - atmospheric_table[idx-1].pressure_Pa);
+    return FEET_TO_METERS * feet;
+}
+
+/*
+  return an interpolated density in meters given a pressure
+ */
+static float lookup_atmospheric_table_density_by_pressure(const float pressure)
+{
+    uint32_t idx = lookup_atmospheric_table_by_pressure(pressure);
+    const float slope =
+        (atmospheric_table[idx].density - atmospheric_table[idx-1].density) /
+        (atmospheric_table[idx-1].pressure_Pa - atmospheric_table[idx].pressure_Pa);
+    return atmospheric_table[idx-1].density - slope * (pressure - atmospheric_table[idx-1].pressure_Pa);
+}
+
+/*
+  return an interpolated density in meters given an altitude
+ */
+static float lookup_atmospheric_table_density_by_alt(const float alt_amsl)
+{
+    uint32_t idx = lookup_atmospheric_table_by_alt(alt_amsl);
+    const float alt_feet = alt_amsl / FEET_TO_METERS;
+    const float slope =
+        (atmospheric_table[idx].density - atmospheric_table[idx-1].density) /
+        (atmospheric_table[idx-1].amsl_feet - atmospheric_table[idx].amsl_feet);
+    return atmospheric_table[idx-1].density - slope * (alt_feet - atmospheric_table[idx-1].amsl_feet);
+}
+
+
+/*
+  return altitude difference in meters between current pressure and a
+  given base_pressure in Pascal. This is a simple atmospheric model
+  good to about 11km AMSL. Enable the table based function for higher altitudes
+*/
+float AP_Baro::get_altitude_difference_table(float base_pressure, float pressure) const
+{
+    const float alt1 = lookup_atmospheric_table_alt(base_pressure);
+    const float alt2 = lookup_atmospheric_table_alt(pressure);
+    return alt2 - alt1;
+}
+
+/*
+  lookup expected pressure for a given altitude. Used for SITL
+*/
+void AP_Baro::get_pressure_temperature_for_alt_amsl(float alt_m, float &pressure, float &temperature_K)
+{
+    const float alt_feet = alt_m / FEET_TO_METERS;
+    uint32_t idx = lookup_atmospheric_table_by_alt(alt_m);
+    const float temp_zero = 288.2;
+    // to match SITL assumed board temperature behaviour we start at 30C
+    const float temp_sea_level = C_TO_KELVIN + 30;
+    const float slopeP =
+        (atmospheric_table[idx-1].pressure_Pa - atmospheric_table[idx].pressure_Pa) /
+        (atmospheric_table[idx].amsl_feet - atmospheric_table[idx-1].amsl_feet);
+    const float slopeT =
+        (atmospheric_table[idx-1].temp_K - atmospheric_table[idx].temp_K) /
+        (atmospheric_table[idx].amsl_feet - atmospheric_table[idx-1].amsl_feet);
+    pressure = atmospheric_table[idx-1].pressure_Pa - slopeP * (alt_feet - atmospheric_table[idx-1].amsl_feet);
+    temperature_K = atmospheric_table[idx-1].temp_K - slopeT * (alt_feet - atmospheric_table[idx-1].amsl_feet);
+    temperature_K += (temp_sea_level - temp_zero);
+}
+
+/*
+  return current scale factor that converts from equivalent to true airspeed
+  uses atmospheric tables
+*/
+float AP_Baro::get_EAS2TAS_table(float pressure)
+{
+    float density = lookup_atmospheric_table_density_by_pressure(pressure);
+    if (!is_positive(density)) {
+        // we really are not likely to get this high
+        const uint32_t table_size = ARRAY_SIZE(atmospheric_table);
+        density = atmospheric_table[table_size-1].density;
+    }
+    return sqrtf(SSL_AIR_DENSITY / density);
+}
+
+/*
+  return air density for altitude, used for SITL
+*/
+float AP_Baro::get_air_density_for_alt_amsl(float alt_amsl)
+{
+    return lookup_atmospheric_table_density_by_alt(alt_amsl);
+}
+
+/*
+  return scale factor that converts from equivalent to true airspeed
+  used by SITL only
+*/
+float AP_Baro::get_EAS2TAS_for_alt_amsl(float alt_amsl)
+{
+    const float density = get_air_density_for_alt_amsl(alt_amsl);
+    return sqrtf(SSL_AIR_DENSITY / MAX(0.00001,density));
+}
+
+#endif // HAL_BARO_ATMOSPHERIC_TABLE || CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
+/*
+  return altitude difference given two pressures
+ */
+float AP_Baro::get_altitude_difference(float base_pressure, float pressure) const
+{
+#if HAL_BARO_ATMOSPHERIC_TABLE
+    return get_altitude_difference_table(base_pressure, pressure);
+#else
+    return get_altitude_difference_function(base_pressure, pressure);
+#endif
+}
+
+
+/*
+  return current scale factor that converts from equivalent to true airspeed
+  valid for altitudes up to 10km AMSL
+  assumes standard atmosphere lapse rate
+*/
+float AP_Baro::get_EAS2TAS_function(float altitude, float pressure)
+{
+    if (is_zero(pressure)) {
+        return 1.0f;
+    }
+
+    // only estimate lapse rate for the difference from the ground location
+    // provides a more consistent reading then trying to estimate a complete
+    // ISA model atmosphere
+    float tempK = get_ground_temperature() + C_TO_KELVIN - ISA_LAPSE_RATE * altitude;
+    const float eas2tas_squared = SSL_AIR_DENSITY / (pressure / (ISA_GAS_CONSTANT * tempK));
+    if (!is_positive(eas2tas_squared)) {
+        return 1.0f;
+    }
+    return sqrtf(eas2tas_squared);
+}
+
+
+/*
+  return current scale factor that converts from equivalent to true airspeed
+*/
+float AP_Baro::get_EAS2TAS(void)
+{
+    const float pressure = get_pressure();
+
+#if HAL_BARO_ATMOSPHERIC_TABLE
+    return get_EAS2TAS_table(pressure);
+#else
+    // otherwise use function
+    return get_EAS2TAS_function(get_altitude(), pressure);
+#endif
+}
+

--- a/libraries/AP_Baro/AP_Baro_atmosphere.cpp
+++ b/libraries/AP_Baro/AP_Baro_atmosphere.cpp
@@ -1,4 +1,6 @@
 #include "AP_Baro.h"
+#include <AP_InternalError/AP_InternalError.h>
+
 /*
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -13,22 +15,49 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-/*
-  atmospheric model options
- */
 
-#ifndef HAL_BARO_ATMOSPHERIC_TABLE
-// default to using tables when doing double precision EKF (which implies more flash space and faster MCU)
-// this allows for non-table testing with --ekf-single configure option
-#define HAL_BARO_ATMOSPHERIC_TABLE HAL_WITH_EKF_DOUBLE
+/* 1976 U.S. Standard Atmosphere: https://ntrs.nasa.gov/api/citations/19770009539/downloads/19770009539.pdf?attachment=true
+
+The US Standard Atmosphere defines the atmopshere in terms of whether the temperature is an iso-thermal or gradient layer.
+Ideal gas laws apply thus P = rho * R_specific * T : P = pressure, rho = density, R_specific = air gas constant, T = temperature
+
+Note: the 1976 model is the same as the 1962 US Standard Atomsphere up to 51km.
+R_universal: the universal gas constant is slightly off in the 1976 model and thus R_specific is different than today's value
+
+*/
+
+/* Model Constants
+R_universal = 8.31432e-3;   // Universal gas constant (J/(kmol-K)) incorrect to the redefined 2019 value of 8.31446261815324 J⋅K−1⋅mol−1
+M_air  = (0.78084 * 28.0134 + 0.209476 * 31.9988 + 9.34e-3 * 39.948 + 3.14e-4 * 44.00995 + 1.818e-5 * 20.183 + 5.24E-6 * 4.0026 + 1.14E-6 * 83.8 + 8.7E-7 * 131.30 + 2E-6 * 16.04303 + 5E-7 * 2.01594) * 1E-3; (kg/mol)
+M_air = 28.9644             // Molecular weight of air (kg/kmol) see page 3
+R_specific  = 287.053072    // air specifc gas constant (J⋅kg−1⋅K−1), R_universal / M_air;
+gama = 1.4;                 // specific heat ratio of air used to determine the speed of sound
+
+R0 = 6356.766E3;            // Earth's radius (in m)
+g0 = 9.80665;               // gravity (m/s^2)
+
+Sea-Level Constants
+H_asml = 0 meters
+T0     = 288.150 K
+P0     = 101325 Pa
+rho0   = 1.2250 kg/m^3 
+T0_slope = -6.5E-3 (K/m')
+
+The tables list altitudes -5 km to 0 km using the same equations as 0 km to 11 km.
+*/
+
+#ifndef HAL_BARO_ATMOSPHERIC_EXTENDED
+// default to using the extended functions when doing double precision EKF (which implies more flash space and faster MCU)
+// this allows for using the simple model with the --ekf-single configure option
+#define HAL_BARO_ATMOSPHERIC_EXTENDED HAL_WITH_EKF_DOUBLE
 #endif
 
 /*
   return altitude difference in meters between current pressure and a
   given base_pressure in Pascal. This is a simple atmospheric model
-  good to about 11km AMSL. Enable the table based function for higher altitudes
+  good to about 11km AMSL.
 */
-float AP_Baro::get_altitude_difference_function(float base_pressure, float pressure) const
+float AP_Baro::get_altitude_difference_simple(float base_pressure, float pressure) const
 {
     float ret;
     float temp    = get_ground_temperature() + C_TO_KELVIN;
@@ -41,290 +70,185 @@ float AP_Baro::get_altitude_difference_function(float base_pressure, float press
     return ret;
 }
 
-#if HAL_BARO_ATMOSPHERIC_TABLE || CONFIG_HAL_BOARD == HAL_BOARD_SITL
-/*
-  MIL-STD 3013 (1962 U.S. Standard Atmosphere) in Tabular Form.
+#if HAL_BARO_ATMOSPHERIC_EXTENDED || CONFIG_HAL_BOARD == HAL_BOARD_SITL
 
-  Using this table is more accurate over a much wider range of
-  altitudes than using the function
- */
+// Note parameters are as defined in the 1976 model
+const float radius_earth = 6356.766E3;      // Earth's radius (in m)
+const float R_specific = 287.053072;        // air specifc gas constant (J⋅kg−1⋅K−1) in 1976 model, R_universal / M_air;
+
 static const struct {
-    float amsl_feet;
-    float temp_K;
-    float pressure_Pa;
-    float density;
-} atmospheric_table[] = {
-    { -15000, 317.9, 169732.9, 1.86000},
-    { -14000, 315.9, 164245.9, 1.81156},
-    { -13000, 313.9, 158903.4, 1.76363},
-    { -12000, 311.9, 153702.6, 1.71673},
-    { -11000, 309.9, 148640.3, 1.67086},
-    { -10000, 308.0, 143714.4, 1.62550},
-    { -9000, 306.0, 138921.1, 1.58170},
-    { -8000, 304.0, 134258.0, 1.53841},
-    { -7000, 302.0, 129722.3, 1.49614},
-    { -6000, 300.0, 125311.6, 1.45491},
-    { -5000, 298.1, 121023.5, 1.41471},
-    { -4000, 296.1, 116854.5, 1.37503},
-    { -3000, 294.1, 112802.9, 1.33638},
-    { -2000, 292.1, 108865.7, 1.29824},
-    { -1000, 290.1, 105040.6, 1.26113},
-    { 0, 288.2, 101325.1, 1.22506},
-    { 1000, 286.2, 97716.8, 1.18949},
-    { 2000, 284.2, 94212.9, 1.15496},
-    { 3000, 282.2, 90811.5, 1.12095},
-    { 4000, 280.2, 87510.7, 1.08796},
-    { 5000, 278.2, 84307.5, 1.05550},
-    { 6000, 276.3, 81199.6, 1.02406},
-    { 7000, 274.3, 78185.5, 0.99313},
-    { 8000, 272.3, 75262.4, 0.96273},
-    { 9000, 270.3, 72428.4, 0.93335},
-    { 10000, 268.3, 69681.5, 0.90449},
-    { 11000, 266.4, 67019.8, 0.87666},
-    { 12000, 264.4, 64440.5, 0.84934},
-    { 13000, 262.4, 61942.6, 0.82254},
-    { 14000, 260.4, 59523.7, 0.79626},
-    { 15000, 258.4, 57181.9, 0.77101},
-    { 16000, 256.5, 54915.2, 0.74575},
-    { 17000, 254.5, 52721.9, 0.72153},
-    { 18000, 252.5, 50599.8, 0.69834},
-    { 19000, 250.5, 48547.7, 0.67515},
-    { 20000, 248.5, 46563.0, 0.65247},
-    { 21000, 246.5, 44644.9, 0.63082},
-    { 22000, 244.6, 42791.5, 0.60969},
-    { 23000, 242.6, 41000.3, 0.58856},
-    { 24000, 240.6, 39270.9, 0.56846},
-    { 25000, 238.6, 37600.8, 0.54888},
-    { 26000, 236.6, 35988.7, 0.52981},
-    { 27000, 234.7, 34433.1, 0.51120},
-    { 28000, 232.7, 32932.0, 0.49306},
-    { 29000, 230.7, 31484.6, 0.47544},
-    { 31000, 226.7, 28744.4, 0.44163},
-    { 32000, 224.8, 27448.8, 0.42545},
-    { 33000, 222.8, 26200.5, 0.40973},
-    { 34000, 220.8, 24998.7, 0.39442},
-    { 35000, 218.8, 23841.9, 0.37958},
-    { 36000, 216.8, 22729.2, 0.36520},
-    { 36089, 216.7, 22632.0, 0.36391},
-    { 37000, 216.7, 21662.4, 0.34834},
-    { 38000, 216.7, 20645.9, 0.33201},
-    { 39000, 216.7, 19677.3, 0.31639},
-    { 40000, 216.7, 18753.7, 0.30155},
-    { 41000, 216.7, 17873.7, 0.28743},
-    { 42000, 216.7, 17034.8, 0.27392},
-    { 43000, 216.7, 16235.7, 0.26109},
-    { 44000, 216.7, 15473.9, 0.24882},
-    { 45000, 216.7, 14747.6, 0.23713},
-    { 46000, 216.7, 14055.7, 0.22599},
-    { 47000, 216.7, 13395.9, 0.21543},
-    { 48000, 216.7, 12767.3, 0.20528},
-    { 49000, 216.7, 12168.3, 0.19564},
-    { 50000, 216.7, 11597.1, 0.18646},
-    { 51000, 216.7, 11053.1, 0.17775},
-    { 52000, 216.7, 10534.1, 0.16941},
-    { 53000, 216.7, 10040.0, 0.16142},
-    { 54000, 216.7, 9568.9, 0.15384},
-    { 55000, 216.7, 9119.7, 0.14663},
-    { 56000, 216.7, 8691.7, 0.13977},
-    { 57000, 216.7, 8283.8, 0.13323},
-    { 58000, 216.7, 7895.0, 0.12694},
-    { 59000, 216.7, 7524.9, 0.12101},
-    { 60000, 216.7, 7171.5, 0.11534},
-    { 61000, 216.7, 6834.9, 0.10993},
-    { 62000, 216.7, 6514.1, 0.10472},
-    { 63000, 216.7, 6208.6, 0.09983},
-    { 64000, 216.7, 5917.0, 0.09514},
-    { 65000, 216.7, 5639.3, 0.09071},
-    { 65617, 216.7, 5474.6, 0.08803},
-    { 66000, 216.8, 5375.0, 0.08638},
-    { 67000, 217.1, 5123.2, 0.08220},
-    { 68000, 217.4, 4883.3, 0.07823},
-    { 69000, 217.7, 4654.9, 0.07447},
-    { 70000, 218.0, 4437.5, 0.07092},
-    { 71000, 218.3, 4230.7, 0.06751},
-    { 72000, 218.6, 4033.9, 0.06427},
-    { 73000, 218.9, 3846.2, 0.06123},
-    { 74000, 219.2, 3667.6, 0.05829},
-    { 76000, 219.8, 3335.8, 0.05288},
-    { 77000, 220.1, 3181.6, 0.05035},
-    { 78000, 220.4, 3034.6, 0.04796},
-    { 79000, 220.7, 2894.8, 0.04569},
-    { 80000, 221.0, 2761.3, 0.04352},
-    { 81000, 221.3, 2634.4, 0.04146},
-    { 82000, 221.6, 2513.2, 0.03950},
-    { 83000, 222.0, 2398.3, 0.03764},
-    { 84000, 222.3, 2288.2, 0.03587},
-    { 85000, 222.6, 2183.8, 0.03418},
-    { 86000, 222.9, 2083.7, 0.03258},
-    { 87000, 223.2, 1988.9, 0.03105},
-    { 88000, 223.5, 1898.5, 0.02959},
-    { 89000, 223.8, 1811.8, 0.02821},
-    { 90000, 224.1, 1729.4, 0.02689},
-    { 91000, 224.4, 1650.9, 0.02563},
-    { 92000, 224.7, 1576.2, 0.02444},
-    { 93000, 225.0, 1504.9, 0.02330},
-    { 94000, 225.3, 1436.9, 0.02222},
-    { 95000, 225.6, 1372.2, 0.02119},
-    { 96000, 225.9, 1310.0, 0.02020},
-    { 97000, 226.2, 1251.1, 0.01927},
-    { 98000, 226.5, 1195.1, 0.01838},
-    { 99000, 226.8, 1141.5, 0.01753},
-    { 100000, 227.1, 1090.2, 0.01672},
-    { 105000, 228.7, 867.6, 0.01321},
-    { 110000, 232.9, 692.3, 0.01035},
-    { 115000, 237.2, 554.9, 0.00815},
-    { 120000, 241.5, 446.2, 0.00644},
-    { 125000, 245.7, 360.5, 0.00511},
-    { 130000, 250.0, 292.1, 0.00407},
-    { 135000, 254.3, 237.5, 0.00326},
-    { 140000, 258.5, 193.9, 0.00261},
-    { 145000, 262.8, 159.0, 0.00211},
-    { 150000, 267.1, 130.7, 0.00170},
+    float amsl_m;       // geopotential height above mean sea-level (km')
+    float temp_K;       // Temperature (K)
+    float pressure_Pa;  // Pressure (Pa)
+    float density;      // Density (Pa/kg)
+    float temp_lapse;   // Temperature gradients rates (K/m'), see page 3
+} atmospheric_1976_consts[] = {
+    { -5000,    320.650,     177687,      1.930467,    -6.5E-3 },
+    { 11000,    216.650,    22632.1,      0.363918,          0 },
+    { 20000,    216.650,    5474.89,    8.80349E-2,       1E-3 },
+    { 32000,    228.650,    868.019,    1.32250E-2,     2.8E-3 },
+    { 47000,    270.650,    110.906,    1.42753E-3,          0 },
+    { 51000,    270.650,    66.9389,    8.61606E-4,    -2.8E-3 },
+    { 71000,    214.650,    3.95642,    6.42110E-5,    -2.0E-3 },
+    { 84852,    186.946,    0.37338,    6.95788E-6,          0 },
 };
 
 /*
-  find table entry given pressure. This returns at least 1
+  find table entry given geopotential altitude in meters. This returns at least 1
  */
-static uint32_t lookup_atmospheric_table_by_pressure(float pressure)
+static uint8_t find_atmosphere_layer_by_altitude(float alt_m)
 {
-    const uint32_t table_size = ARRAY_SIZE(atmospheric_table);
-    uint32_t idx_min = 1;
-    uint32_t idx_max = table_size-1;
-    if (pressure > atmospheric_table[0].pressure_Pa) {
-        // off the bottom of the table
-        idx_max = 1;
-    }
-    while (idx_min < idx_max) {
-        const uint32_t mid = (idx_max+idx_min)/2;
-        if (atmospheric_table[mid].pressure_Pa < pressure) {
-            idx_max = mid;
-        } else {
-            idx_min = mid+1;
+    for (uint8_t idx = 1; idx < ARRAY_SIZE(atmospheric_1976_consts); idx++) {
+        if(alt_m < atmospheric_1976_consts[idx].amsl_m) {
+            return idx - 1;
         }
     }
-    return idx_min;
+
+    // Over the largest altitude return the last index
+    return ARRAY_SIZE(atmospheric_1976_consts) - 1;
 }
 
 /*
-  find table entry given altitude in meters. This returns at least 1
+  find table entry given pressure (Pa). This returns at least 1
  */
-static uint32_t lookup_atmospheric_table_by_alt(float alt_m)
+static uint8_t find_atmosphere_layer_by_pressure(float pressure)
 {
-    const uint32_t table_size = ARRAY_SIZE(atmospheric_table);
-    uint32_t idx_min = 1;
-    uint32_t idx_max = table_size-1;
-    float alt_feet = alt_m / FEET_TO_METERS;
-    if (alt_feet <= atmospheric_table[0].amsl_feet) {
-        // off the bottom of the table
-        idx_max = 1;
-    }
-    while (idx_min < idx_max) {
-        const uint32_t mid = (idx_max+idx_min)/2;
-        if (atmospheric_table[mid].amsl_feet > alt_feet) {
-            idx_max = mid;
-        } else {
-            idx_min = mid+1;
+
+    for (uint8_t idx = 1; idx < ARRAY_SIZE(atmospheric_1976_consts); idx++) {
+        if(atmospheric_1976_consts[idx].pressure_Pa < pressure) {
+            return idx - 1;
         }
     }
-    return idx_min;
+
+    // pressure is less than the smallest pressure return the last index
+    return ARRAY_SIZE(atmospheric_1976_consts) - 1;
+
 }
 
-/*
-  return an interpolated altitude in meters given a pressure
- */
-static float lookup_atmospheric_table_alt(const float pressure)
+// Convert geopotential altitude to geometric altitude
+// 
+float AP_Baro::geopotential_alt_to_geometric(float alt)
 {
-    uint32_t idx = lookup_atmospheric_table_by_pressure(pressure);
-    const float slope =
-        (atmospheric_table[idx].amsl_feet - atmospheric_table[idx-1].amsl_feet) /
-        (atmospheric_table[idx-1].pressure_Pa - atmospheric_table[idx].pressure_Pa);
-    const float feet = atmospheric_table[idx-1].amsl_feet - slope * (pressure - atmospheric_table[idx-1].pressure_Pa);
-    return FEET_TO_METERS * feet;
+    return (radius_earth * alt) / (radius_earth - alt);
 }
 
-/*
-  return an interpolated density in meters given a pressure
- */
-static float lookup_atmospheric_table_density_by_pressure(const float pressure)
+float AP_Baro::geometric_alt_to_geopotential(float alt)
 {
-    uint32_t idx = lookup_atmospheric_table_by_pressure(pressure);
-    const float slope =
-        (atmospheric_table[idx].density - atmospheric_table[idx-1].density) /
-        (atmospheric_table[idx-1].pressure_Pa - atmospheric_table[idx].pressure_Pa);
-    return atmospheric_table[idx-1].density - slope * (pressure - atmospheric_table[idx-1].pressure_Pa);
+    return (radius_earth * alt) / (radius_earth + alt);
 }
 
 /*
-  return an interpolated density in meters given an altitude
- */
-static float lookup_atmospheric_table_density_by_alt(const float alt_amsl)
-{
-    uint32_t idx = lookup_atmospheric_table_by_alt(alt_amsl);
-    const float alt_feet = alt_amsl / FEET_TO_METERS;
-    const float slope =
-        (atmospheric_table[idx].density - atmospheric_table[idx-1].density) /
-        (atmospheric_table[idx-1].amsl_feet - atmospheric_table[idx].amsl_feet);
-    return atmospheric_table[idx-1].density - slope * (alt_feet - atmospheric_table[idx-1].amsl_feet);
-}
-
-
-/*
-  return altitude difference in meters between current pressure and a
-  given base_pressure in Pascal. This is a simple atmospheric model
-  good to about 11km AMSL. Enable the table based function for higher altitudes
+  Compute expected temperature for a given geometric altitude and altitude layer.
 */
-float AP_Baro::get_altitude_difference_table(float base_pressure, float pressure) const
+float AP_Baro::get_temperature_from_altitude(float alt) const
 {
-    const float alt1 = lookup_atmospheric_table_alt(base_pressure);
-    const float alt2 = lookup_atmospheric_table_alt(pressure);
-    return alt2 - alt1;
+    alt = geometric_alt_to_geopotential(alt);
+    const uint8_t idx = find_atmosphere_layer_by_altitude(alt);
+    return get_temperature_by_altitude_layer(alt, idx);
 }
 
 /*
-  lookup expected pressure for a given altitude. Used for SITL
+  Compute expected temperature for a given geopotential altitude and altitude layer.
 */
-void AP_Baro::get_pressure_temperature_for_alt_amsl(float alt_m, float &pressure, float &temperature_K)
+float AP_Baro::get_temperature_by_altitude_layer(float alt, int8_t idx)
 {
-    const float alt_feet = alt_m / FEET_TO_METERS;
-    uint32_t idx = lookup_atmospheric_table_by_alt(alt_m);
-    const float temp_zero = 288.2;
-    // to match SITL assumed board temperature behaviour we start at 30C
-    const float temp_sea_level = C_TO_KELVIN + 30;
-    const float slopeP =
-        (atmospheric_table[idx-1].pressure_Pa - atmospheric_table[idx].pressure_Pa) /
-        (atmospheric_table[idx].amsl_feet - atmospheric_table[idx-1].amsl_feet);
-    const float slopeT =
-        (atmospheric_table[idx-1].temp_K - atmospheric_table[idx].temp_K) /
-        (atmospheric_table[idx].amsl_feet - atmospheric_table[idx-1].amsl_feet);
-    pressure = atmospheric_table[idx-1].pressure_Pa - slopeP * (alt_feet - atmospheric_table[idx-1].amsl_feet);
-    temperature_K = atmospheric_table[idx-1].temp_K - slopeT * (alt_feet - atmospheric_table[idx-1].amsl_feet);
-    temperature_K += (temp_sea_level - temp_zero);
+    if (is_zero(atmospheric_1976_consts[idx].temp_lapse)) {
+        return atmospheric_1976_consts[idx].temp_K;
+    }
+    return  atmospheric_1976_consts[idx].temp_K + atmospheric_1976_consts[idx].temp_lapse * (alt - atmospheric_1976_consts[idx].amsl_m);
+}
+
+/*
+  return geometric altitude (m) given a pressure (Pa)
+*/
+float AP_Baro::get_altitude_from_pressure(float pressure) const
+{
+    const uint8_t idx = find_atmosphere_layer_by_pressure(pressure);
+    const float pressure_ratio = pressure / atmospheric_1976_consts[idx].pressure_Pa;
+
+    // Pressure ratio is nonsensical return an error??
+    if (!is_positive(pressure_ratio)) {
+        INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+        return get_altitude();
+    }
+
+    float alt;
+    const float temp_slope = atmospheric_1976_consts[idx].temp_lapse;
+    if (is_zero(temp_slope)) {  // Iso-thermal layer
+        const float fac = -(atmospheric_1976_consts[idx].temp_K * R_specific) / GRAVITY_MSS;
+        alt = atmospheric_1976_consts[idx].amsl_m + fac * logf(pressure_ratio);
+    } else {                    // Gradient temperature layer
+        const float fac = -(temp_slope * R_specific) / GRAVITY_MSS;
+        alt = atmospheric_1976_consts[idx].amsl_m + (atmospheric_1976_consts[idx].temp_K / atmospheric_1976_consts[idx].temp_lapse) * (powf(pressure_ratio, fac) - 1);
+    }
+
+    return geopotential_alt_to_geometric(alt);
+}
+
+/*
+  Compute expected pressure and temperature for a given geometric altitude. Used for SITL
+*/
+void AP_Baro::get_pressure_temperature_for_alt_amsl(float alt_amsl, float &pressure, float &temperature_K)
+{
+    alt_amsl = geometric_alt_to_geopotential(alt_amsl);
+
+    const uint8_t idx = find_atmosphere_layer_by_altitude(alt_amsl);
+    const float temp_slope = atmospheric_1976_consts[idx].temp_lapse;
+    temperature_K =  get_temperature_by_altitude_layer(alt_amsl, idx);
+
+    // Previous versions used the current baro temperature instead of an estimate we could try to incorporate this??? non-standard atmosphere
+    // const float temp =  get_temperature();
+
+    if (is_zero(temp_slope)) {    // Iso-thermal layer
+        const float fac = expf(-GRAVITY_MSS / (temperature_K * R_specific) * (alt_amsl - atmospheric_1976_consts[idx].amsl_m));
+        pressure = atmospheric_1976_consts[idx].pressure_Pa * fac;
+    } else {            // Gradient temperature layer
+        const float fac =  GRAVITY_MSS / (temp_slope * R_specific);
+        const float temp_ratio = temperature_K / atmospheric_1976_consts[idx].temp_K; // temperature ratio [unitless]
+        pressure = atmospheric_1976_consts[idx].pressure_Pa * powf(temp_ratio, -fac);
+    }
+}
+
+/*
+  return air density (kg/m^3), given geometric altitude (m)
+*/
+float AP_Baro::get_air_density_for_alt_amsl(float alt_amsl)
+{
+    alt_amsl = geometric_alt_to_geopotential(alt_amsl);
+
+    const uint8_t idx = find_atmosphere_layer_by_altitude(alt_amsl);
+    const float temp_slope = atmospheric_1976_consts[idx].temp_lapse;
+    const float temp =  get_temperature_by_altitude_layer(alt_amsl, idx);
+    // const float temp =  get_temperature();
+
+    float rho;
+    if (is_zero(temp_slope)) {    // Iso-thermal layer
+        const float fac = expf(-GRAVITY_MSS / (temp * R_specific) * (alt_amsl - atmospheric_1976_consts[idx].amsl_m));
+        rho      = atmospheric_1976_consts[idx].density     * fac;
+    } else {            // Gradient temperature layer
+        const float fac =  GRAVITY_MSS / (temp_slope * R_specific);
+        const float temp_ratio = temp / atmospheric_1976_consts[idx].temp_K; // temperature ratio [unitless]
+        rho      = atmospheric_1976_consts[idx].density     * powf(temp_ratio, -(fac + 1));
+    }
+    return rho;
 }
 
 /*
   return current scale factor that converts from equivalent to true airspeed
-  uses atmospheric tables
 */
-float AP_Baro::get_EAS2TAS_table(float pressure)
+float AP_Baro::get_EAS2TAS_extended(float altitude) const
 {
-    float density = lookup_atmospheric_table_density_by_pressure(pressure);
+    float density = get_air_density_for_alt_amsl(altitude);
     if (!is_positive(density)) {
-        // we really are not likely to get this high
-        const uint32_t table_size = ARRAY_SIZE(atmospheric_table);
-        density = atmospheric_table[table_size-1].density;
+        // above this height we are getting closer to spacecraft territory...
+        const uint8_t table_size = ARRAY_SIZE(atmospheric_1976_consts);
+        density = atmospheric_1976_consts[table_size-1].density;
     }
     return sqrtf(SSL_AIR_DENSITY / density);
 }
 
 /*
-  return air density for altitude, used for SITL
-*/
-float AP_Baro::get_air_density_for_alt_amsl(float alt_amsl)
-{
-    return lookup_atmospheric_table_density_by_alt(alt_amsl);
-}
-
-/*
+  Given the geometric altitude (m)
   return scale factor that converts from equivalent to true airspeed
   used by SITL only
 */
@@ -334,27 +258,29 @@ float AP_Baro::get_EAS2TAS_for_alt_amsl(float alt_amsl)
     return sqrtf(SSL_AIR_DENSITY / MAX(0.00001,density));
 }
 
-#endif // HAL_BARO_ATMOSPHERIC_TABLE || CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#endif // HAL_BARO_ATMOSPHERIC_EXTENDED || CONFIG_HAL_BOARD == HAL_BOARD_SITL
 
 /*
-  return altitude difference given two pressures
- */
+  return geometric altitude difference in meters between current pressure and a
+  given base_pressure in Pascal.
+*/
 float AP_Baro::get_altitude_difference(float base_pressure, float pressure) const
 {
-#if HAL_BARO_ATMOSPHERIC_TABLE
-    return get_altitude_difference_table(base_pressure, pressure);
+#if HAL_BARO_ATMOSPHERIC_EXTENDED
+    const float alt1 = get_altitude_from_pressure(base_pressure);
+    const float alt2 = get_altitude_from_pressure(pressure);
+    return alt2 - alt1;
 #else
-    return get_altitude_difference_function(base_pressure, pressure);
+    return get_altitude_difference_simple(base_pressure, pressure);
 #endif
 }
 
-
 /*
   return current scale factor that converts from equivalent to true airspeed
-  valid for altitudes up to 10km AMSL
-  assumes standard atmosphere lapse rate
+  valid for altitudes up to 11km AMSL
+  assumes USA 1976 standard atmosphere lapse rate
 */
-float AP_Baro::get_EAS2TAS_function(float altitude, float pressure)
+float AP_Baro::get_EAS2TAS_simple(float altitude, float pressure) const
 {
     if (is_zero(pressure)) {
         return 1.0f;
@@ -371,19 +297,17 @@ float AP_Baro::get_EAS2TAS_function(float altitude, float pressure)
     return sqrtf(eas2tas_squared);
 }
 
-
 /*
   return current scale factor that converts from equivalent to true airspeed
 */
-float AP_Baro::get_EAS2TAS(void)
+float AP_Baro::get_EAS2TAS(void) const
 {
-    const float pressure = get_pressure();
+    const float altitude = get_altitude();
 
-#if HAL_BARO_ATMOSPHERIC_TABLE
-    return get_EAS2TAS_table(pressure);
+#if HAL_BARO_ATMOSPHERIC_EXTENDED
+    return get_EAS2TAS_extended(altitude);
 #else
     // otherwise use function
-    return get_EAS2TAS_function(get_altitude(), pressure);
+    return get_EAS2TAS_simple(altitude, get_pressure());
 #endif
 }
-

--- a/libraries/AP_Baro/tests/test_baro_atmosphere.cpp
+++ b/libraries/AP_Baro/tests/test_baro_atmosphere.cpp
@@ -1,0 +1,128 @@
+#include <AP_gtest.h>
+
+// #define HAL_BARO_ATMOSPHERIC_EXTENDED 1
+#include <AP_Baro/AP_Baro.h>
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+// EXPECT_NEAR(AP_Baro::get_EAS2TAS_extended(6000), sqrtf(SSL_AIR_DENSITY / 0.6601));
+// EXPECT_NEAR(AP_Baro::get_EAS2TAS_simple(6000), sqrtf(SSL_AIR_DENSITY / 0.6601));
+
+TEST(AP_Baro, get_air_density_for_alt_amsl)
+{
+    float accuracy = 1E-6;
+
+    EXPECT_NEAR(AP_Baro::get_air_density_for_alt_amsl(-4000), 1.7697266, accuracy);
+    EXPECT_NEAR(AP_Baro::get_air_density_for_alt_amsl(6000), 0.66011156, accuracy);
+    EXPECT_NEAR(AP_Baro::get_air_density_for_alt_amsl(17500), 131.5688E-3, accuracy);
+    EXPECT_NEAR(AP_Baro::get_air_density_for_alt_amsl(25000), 40.08393E-3, accuracy);
+    EXPECT_NEAR(AP_Baro::get_air_density_for_alt_amsl(40000), 3.99567824728293E-3, accuracy);
+    EXPECT_NEAR(AP_Baro::get_air_density_for_alt_amsl(49000), 1.16276961471707E-3, accuracy);
+    EXPECT_NEAR(AP_Baro::get_air_density_for_alt_amsl(65000), 163.210100967015E-6, accuracy);
+    EXPECT_NEAR(AP_Baro::get_air_density_for_alt_amsl(78000), 25.2385188936996E-6, accuracy);
+}
+
+TEST(AP_Baro, get_altitude_from_pressure)
+{
+    AP_Baro baro;
+    float accuracy = 1.5E-1;
+
+    EXPECT_NEAR(baro.get_altitude_from_pressure(159598.2), -4000, accuracy);
+    EXPECT_NEAR(baro.get_altitude_from_pressure(47217.6), 6000, accuracy);
+    EXPECT_NEAR(baro.get_altitude_from_pressure(8182.3), 17500, accuracy);
+    EXPECT_NEAR(baro.get_altitude_from_pressure(2549.2), 25000, accuracy);
+    EXPECT_NEAR(baro.get_altitude_from_pressure(287.1441), 40000, accuracy);
+    EXPECT_NEAR(baro.get_altitude_from_pressure(90.3365), 49000, accuracy);
+    EXPECT_NEAR(baro.get_altitude_from_pressure(10.9297), 65000, accuracy);
+    EXPECT_NEAR(baro.get_altitude_from_pressure(1.4674), 78000, accuracy);
+}
+
+TEST(AP_Baro, get_temperature_from_altitude)
+{
+    AP_Baro baro;
+
+    EXPECT_FLOAT_EQ(baro.get_temperature_from_altitude(-4000), 314.166370821781);
+    EXPECT_FLOAT_EQ(baro.get_temperature_from_altitude(6000), 249.186776458540);
+    EXPECT_FLOAT_EQ(baro.get_temperature_from_altitude(17500), 216.650000000000);
+    EXPECT_FLOAT_EQ(baro.get_temperature_from_altitude(25000), 221.552064726284);
+    EXPECT_FLOAT_EQ(baro.get_temperature_from_altitude(40000), 250.349646102421);
+    EXPECT_FLOAT_EQ(baro.get_temperature_from_altitude(49000), 270.650000000000);
+    EXPECT_FLOAT_EQ(baro.get_temperature_from_altitude(65000), 233.292172386848);
+    EXPECT_FLOAT_EQ(baro.get_temperature_from_altitude(78000), 202.540977853740);
+}
+
+TEST(AP_Baro, geopotential_alt_to_geometric)
+{
+    EXPECT_FLOAT_EQ(AP_Baro::geopotential_alt_to_geometric(-4002.51858796625), -4000);
+    EXPECT_FLOAT_EQ(AP_Baro::geopotential_alt_to_geometric(5994.34208330151), 6000.0);
+    EXPECT_FLOAT_EQ(AP_Baro::geopotential_alt_to_geometric(17451.9552525734), 17500);
+    EXPECT_FLOAT_EQ(AP_Baro::geopotential_alt_to_geometric(24902.0647262842), 25000);
+    EXPECT_FLOAT_EQ(AP_Baro::geopotential_alt_to_geometric(39749.8736080075), 40000);
+    EXPECT_FLOAT_EQ(AP_Baro::geopotential_alt_to_geometric(48625.1814380981), 49000);
+    EXPECT_FLOAT_EQ(AP_Baro::geopotential_alt_to_geometric(64342.0812904114), 65000);
+    EXPECT_FLOAT_EQ(AP_Baro::geopotential_alt_to_geometric(77054.5110731299), 78000);
+}
+
+TEST(AP_Baro, geometric_alt_to_geopotential)
+{
+    EXPECT_FLOAT_EQ(AP_Baro::geometric_alt_to_geopotential(-4000), -4002.51858796625);
+    EXPECT_FLOAT_EQ(AP_Baro::geometric_alt_to_geopotential(6000), 5994.34208330151);
+    EXPECT_FLOAT_EQ(AP_Baro::geometric_alt_to_geopotential(17500), 17451.9552525734);
+    EXPECT_FLOAT_EQ(AP_Baro::geometric_alt_to_geopotential(25000), 24902.0647262842);
+    EXPECT_FLOAT_EQ(AP_Baro::geometric_alt_to_geopotential(40000), 39749.8736080075);
+    EXPECT_FLOAT_EQ(AP_Baro::geometric_alt_to_geopotential(49000), 48625.1814380981);
+    EXPECT_FLOAT_EQ(AP_Baro::geometric_alt_to_geopotential(65000), 64342.0812904114);
+    EXPECT_FLOAT_EQ(AP_Baro::geometric_alt_to_geopotential(78000), 77054.5110731299);
+}
+
+TEST(AP_Baro, get_pressure_temperature_for_alt_amsl)
+{
+    float accuracy = 1E-6;
+
+    // layer 0 -4000 m
+    float pressure, temperature_K;
+    AP_Baro::get_pressure_temperature_for_alt_amsl(-4000, pressure, temperature_K);
+    // EXPECT_FLOAT_EQ(pressure, 159598.164433755);    // Matlab
+    EXPECT_FLOAT_EQ(pressure, 159598.09375);
+    EXPECT_FLOAT_EQ(temperature_K, 314.166370821781);
+
+    // layer 0: 6000 m
+    AP_Baro::get_pressure_temperature_for_alt_amsl(6000, pressure, temperature_K);
+    EXPECT_FLOAT_EQ(pressure, 47217.6489854302);
+    EXPECT_FLOAT_EQ(temperature_K, 249.186776458540);
+
+    // layer 1: 17500 m
+    AP_Baro::get_pressure_temperature_for_alt_amsl(17500, pressure, temperature_K);
+    EXPECT_FLOAT_EQ(pressure, 8182.27857345022);
+    EXPECT_FLOAT_EQ(temperature_K, 216.650000000000);
+
+    // layer 2: 25000m
+    AP_Baro::get_pressure_temperature_for_alt_amsl(25000, pressure, temperature_K);
+    // EXPECT_FLOAT_EQ(pressure, 2549.22361148236);    // Matlab
+    EXPECT_FLOAT_EQ(pressure, 2549.2251);
+    EXPECT_FLOAT_EQ(temperature_K, 221.552064726284);
+
+    // layer 3: 40000m
+    AP_Baro::get_pressure_temperature_for_alt_amsl(40000, pressure, temperature_K);
+    EXPECT_FLOAT_EQ(pressure, 287.144059695555);
+    EXPECT_FLOAT_EQ(temperature_K, 250.349646102421);
+
+    // layer 4: 49000m
+    AP_Baro::get_pressure_temperature_for_alt_amsl(49000, pressure, temperature_K);
+    EXPECT_FLOAT_EQ(pressure, 90.3365441635632);
+    EXPECT_FLOAT_EQ(temperature_K, 270.650000000000);
+
+    // layer 5: 65000m
+    AP_Baro::get_pressure_temperature_for_alt_amsl(65000, pressure, temperature_K);
+    // EXPECT_FLOAT_EQ(pressure, 10.9297197424037);    // Matlab
+    EXPECT_FLOAT_EQ(pressure, 10.929715);
+    EXPECT_FLOAT_EQ(temperature_K, 233.292172386848);
+
+    // layer 6: 78000m
+    AP_Baro::get_pressure_temperature_for_alt_amsl(78000, pressure, temperature_K);
+    // EXPECT_FLOAT_EQ(pressure, 1.46736727632119);    // matlab
+    EXPECT_NEAR(pressure, 1.4673687, accuracy);
+    EXPECT_FLOAT_EQ(temperature_K, 202.540977853740);
+}
+
+AP_GTEST_MAIN()

--- a/libraries/AP_Baro/tests/wscript
+++ b/libraries/AP_Baro/tests/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_find_tests(
+        use='ap',
+    )

--- a/libraries/AP_DAL/AP_DAL.cpp
+++ b/libraries/AP_DAL/AP_DAL.cpp
@@ -58,7 +58,7 @@ void AP_DAL::start_frame(AP_DAL::FrameType frametype)
     _RFRN.lat = _home.lat;
     _RFRN.lng = _home.lng;
     _RFRN.alt = _home.alt;
-    _RFRN.EAS2TAS = AP::baro().get_EAS2TAS();
+    _RFRN.EAS2TAS = ahrs.get_EAS2TAS();
     _RFRN.vehicle_class = (uint8_t)ahrs.get_vehicle_class();
     _RFRN.fly_forward = ahrs.get_fly_forward();
     _RFRN.takeoff_expected = ahrs.get_takeoff_expected();

--- a/libraries/AP_Math/definitions.h
+++ b/libraries/AP_Math/definitions.h
@@ -79,15 +79,15 @@ static const double WGS84_E = (sqrt(2 * WGS84_F - WGS84_F * WGS84_F));
 
 #define KM_PER_HOUR_TO_M_PER_SEC 0.27777778f
 
-// Gas Constant is from Aerodynamics for Engineering Students, Third Edition, E.L.Houghton and N.B.Carruthers
-#define ISA_GAS_CONSTANT 287.26f
-#define ISA_LAPSE_RATE 0.0065f
+// Gas Constant is from https://en.wikipedia.org/wiki/Gas_constant which is computed from the universal gas constant and molecular weight of air
+#define ISA_GAS_CONSTANT 287.05800  // (J⋅K−1⋅mol−1)
+#define ISA_LAPSE_RATE 0.0065       // Troposphere temperature gradient rate (K/m'), note this assumes geopotential altitude (m')
 
 // Standard Sea Level values
 // Ref: https://en.wikipedia.org/wiki/Standard_sea_level
-#define SSL_AIR_DENSITY         1.225f // kg/m^3
-#define SSL_AIR_PRESSURE 101325.01576f // Pascal
-#define SSL_AIR_TEMPERATURE    288.15f // K
+#define SSL_AIR_DENSITY        1.2250 // kg/m^3
+#define SSL_AIR_PRESSURE       101325 // Pascal
+#define SSL_AIR_TEMPERATURE    288.15 // K
 
 #define INCH_OF_H2O_TO_PASCAL 248.84f
 

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -107,6 +107,7 @@ public:
         return velocity_ef;
     }
 
+    // return TAS airspeed in earth frame
     const Vector3f &get_velocity_air_ef(void) const {
         return velocity_air_ef;
     }
@@ -176,13 +177,15 @@ protected:
     float mass;                          // kg
     float external_payload_mass;         // kg
     Vector3f accel_body{0.0f, 0.0f, -GRAVITY_MSS}; // m/s/s NED, body frame
-    float airspeed;                      // m/s, apparent airspeed
-    float airspeed_pitot;                // m/s, apparent airspeed, as seen by fwd pitot tube
+    float airspeed;                      // m/s, EAS airspeed
+    float airspeed_pitot;                // m/s, EAS airspeed, as seen by fwd pitot tube
     float battery_voltage = -1.0f;
     float battery_current;
     float local_ground_level;            // ground level at local position
     bool lock_step_scheduled;
     uint32_t last_one_hz_ms;
+    float eas2tas = 1.0;
+    float air_density = SSL_AIR_DENSITY;
 
     // battery model
     Battery battery;
@@ -304,6 +307,9 @@ protected:
 
     // get local thermal updraft
     float get_local_updraft(const Vector3d &currentPos);
+
+    // update EAS speeds
+    void update_eas_airspeed();
 
 private:
     uint64_t last_time_us;

--- a/libraries/SITL/SIM_Airspeed_DLVR.cpp
+++ b/libraries/SITL/SIM_Airspeed_DLVR.cpp
@@ -60,14 +60,13 @@ void SITL::Airspeed_DLVR::update(const class Aircraft &aircraft)
     }
     last_update_ms = now_ms;
 
-    pressure = AP::sitl()->state.airspeed_raw_pressure[0];
-
     float sim_alt = AP::sitl()->state.altitude;
     sim_alt += 2 * rand_float();
 
-    float sigma, delta, theta;
-    AP_Baro::SimpleAtmosphere(sim_alt * 0.001f, sigma, delta, theta);
+    float p, T;
+    AP_Baro::get_pressure_temperature_for_alt_amsl(sim_alt, p, T);
 
     // To Do: Add a sensor board temperature offset parameter
-    temperature = (SSL_AIR_TEMPERATURE * theta - C_TO_KELVIN) + 25.0;
+    temperature = (T - C_TO_KELVIN) + 25.0;
+    pressure = AP::sitl()->state.airspeed_raw_pressure[0];
 }

--- a/libraries/SITL/SIM_Balloon.cpp
+++ b/libraries/SITL/SIM_Balloon.cpp
@@ -50,7 +50,7 @@ void Balloon::update(const struct sitl_input &input)
     Vector3f rot_accel = -gyro * radians(400) / terminal_rotation_rate;
 
     // air resistance
-    Vector3f air_resistance = -velocity_air_ef * (GRAVITY_MSS/terminal_velocity);
+    Vector3f air_resistance = -velocity_air_ef * (GRAVITY_MSS/terminal_velocity) / eas2tas;
 
     float lift_accel = 0;
     if (!burst && released) {

--- a/libraries/SITL/SIM_Frame.cpp
+++ b/libraries/SITL/SIM_Frame.cpp
@@ -314,12 +314,7 @@ static Frame supported_frames[] =
 // get air density in kg/m^3
 float Frame::get_air_density(float alt_amsl) const
 {
-    float sigma, delta, theta;
-
-    AP_Baro::SimpleAtmosphere(alt_amsl * 0.001f, sigma, delta, theta);
-
-    const float air_pressure = SSL_AIR_PRESSURE * delta;
-    return air_pressure / (ISA_GAS_CONSTANT * (C_TO_KELVIN + model.refTempC));
+    return AP_Baro::get_air_density_for_alt_amsl(alt_amsl);
 }
 
 /*

--- a/libraries/SITL/SIM_JSON.cpp
+++ b/libraries/SITL/SIM_JSON.cpp
@@ -316,6 +316,9 @@ void JSON::recv_fdm(const struct sitl_input &input)
 
         // airspeed as seen by a fwd pitot tube (limited to 120m/s)
         airspeed_pitot = constrain_float(velocity_air_bf * Vector3f(1.0f, 0.0f, 0.0f), 0.0f, 120.0f);
+
+        // airspeed fix for eas2tas
+        update_eas_airspeed();
     }
 
     // Convert from a meters from origin physics to a lat long alt

--- a/libraries/SITL/SIM_LORD.cpp
+++ b/libraries/SITL/SIM_LORD.cpp
@@ -96,9 +96,10 @@ void LORD::send_imu_packet(void)
     // Add ambient pressure field
     packet.payload[packet.payload_size++] = 0x06; // Ambient Pressure Field Size
     packet.payload[packet.payload_size++] = 0x17; // Descriptor
-    float sigma, delta, theta;
-    AP_Baro::SimpleAtmosphere(fdm.altitude * 0.001f, sigma, delta, theta);
-    put_float(packet, SSL_AIR_PRESSURE * delta * 0.001 + rand_float() * 0.1);
+
+    float pressure, temperature;
+    AP_Baro::get_pressure_temperature_for_alt_amsl(fdm.altitude * 0.001, pressure, temperature);
+    put_float(packet, pressure * 0.001 + rand_float() * 0.1);
 
     // Add scaled magnetometer field
     packet.payload[packet.payload_size++] = 0x0E; // Scaled Magnetometer Field Size

--- a/libraries/SITL/SIM_MS5525.cpp
+++ b/libraries/SITL/SIM_MS5525.cpp
@@ -68,10 +68,10 @@ void MS5525::get_pressure_temperature_readings(float &P_Pa, float &Temp_C)
     float sim_alt = AP::sitl()->state.altitude;
     sim_alt += 2 * rand_float();
 
-    float sigma, delta, theta;
-    AP_Baro::SimpleAtmosphere(sim_alt * 0.001f, sigma, delta, theta);
+    float p, T;
+    AP_Baro::get_pressure_temperature_for_alt_amsl(sim_alt, p, T);
 
     // To Do: Add a sensor board temperature offset parameter
-    Temp_C = (SSL_AIR_TEMPERATURE * theta - C_TO_KELVIN) + 25.0;
+    Temp_C = (T - C_TO_KELVIN) + 25.0;
     P_Pa = AP::sitl()->state.airspeed_raw_pressure[0];
 }

--- a/libraries/SITL/SIM_MS5611.cpp
+++ b/libraries/SITL/SIM_MS5611.cpp
@@ -106,15 +106,13 @@ void MS5611::check_conversion_accuracy(float P_Pa, float Temp_C, uint32_t D1, ui
 
 void MS5611::get_pressure_temperature_readings(float &P_Pa, float &Temp_C)
 {
-    float sigma, delta, theta;
-
     float sim_alt = AP::sitl()->state.altitude;
     sim_alt += 2 * rand_float();
 
-    AP_Baro::SimpleAtmosphere(sim_alt * 0.001f, sigma, delta, theta);
-    P_Pa = SSL_AIR_PRESSURE * delta;
-
-    Temp_C = (SSL_AIR_TEMPERATURE * theta - C_TO_KELVIN) + AP::sitl()->temp_board_offset;
+    float p, T;
+    AP_Baro::get_pressure_temperature_for_alt_amsl(sim_alt, p, T);
+    P_Pa = p;
+    Temp_C = (T - C_TO_KELVIN) + AP::sitl()->temp_board_offset;
 
     // TO DO add in temperature adjustment by inheritting from AP_Baro_SITL_Generic?
     // AP_Baro_SITL::temperature_adjustment(P_Pa, Temp_C);

--- a/libraries/SITL/SIM_MS5XXX.cpp
+++ b/libraries/SITL/SIM_MS5XXX.cpp
@@ -58,6 +58,8 @@ void MS5XXX::convert_D2()
         // bug in the conversion code.  The simulation can pass in
         // very, very low numbers.  Clamp it.
         P_Pa = 0.1;
+
+        // This should be a simulation error??? Pressure at 86km is 0.374Pa
     }
 
     uint32_t D1;

--- a/libraries/SITL/SIM_Plane.h
+++ b/libraries/SITL/SIM_Plane.h
@@ -41,7 +41,6 @@ public:
 
 protected:
     const float hover_throttle = 0.7f;
-    const float air_density = 1.225; // kg/m^3 at sea level, ISA conditions
     float angle_of_attack;
     float beta;
 

--- a/libraries/SITL/SIM_SingleCopter.cpp
+++ b/libraries/SITL/SIM_SingleCopter.cpp
@@ -90,7 +90,7 @@ void SingleCopter::update(const struct sitl_input &input)
     rot_accel.z -= gyro.z * radians(400.0)  / terminal_rotation_rate;
 
     // air resistance
-    Vector3f air_resistance = -velocity_air_ef * (GRAVITY_MSS/terminal_velocity);
+    Vector3f air_resistance = -velocity_air_ef * (GRAVITY_MSS/terminal_velocity) / eas2tas;
 
     // scale thrust to newtons
     thrust *= thrust_scale;

--- a/libraries/SITL/SIM_VectorNav.cpp
+++ b/libraries/SITL/SIM_VectorNav.cpp
@@ -108,9 +108,9 @@ void VectorNav::send_packet1(void)
     pkt.uncompAngRate[1] = radians(fdm.pitchRate + gyro_noise * rand_float());
     pkt.uncompAngRate[2] = radians(fdm.yawRate + gyro_noise * rand_float());
 
-    float sigma, delta, theta;
-    AP_Baro::SimpleAtmosphere(fdm.altitude * 0.001f, sigma, delta, theta);
-    pkt.pressure = SSL_AIR_PRESSURE * delta * 0.001 + rand_float() * 0.01;
+    float p, T;
+    AP_Baro::get_pressure_temperature_for_alt_amsl(fdm.altitude, p, T);
+    pkt.pressure = p*0.001 + rand_float() * 0.01;
 
     pkt.mag[0] = fdm.bodyMagField.x*0.001;
     pkt.mag[1] = fdm.bodyMagField.y*0.001;
@@ -175,7 +175,12 @@ void VectorNav::send_packet2(void)
     simulation_timeval(&tv);
 
     pkt.timeGPS = tv.tv_usec * 1000ULL;
-    pkt.temp = 23.5;
+
+    float p, T;
+    AP_Baro::get_pressure_temperature_for_alt_amsl(fdm.altitude, p, T);
+    T -= C_TO_KELVIN;
+
+    pkt.temp = T;
     pkt.numGPS1Sats = 19;
     pkt.GPS1Fix = 3;
     pkt.GPS1posLLA[0] = fdm.latitude;

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -57,8 +57,8 @@ struct sitl_fdm {
     double rollRate, pitchRate, yawRate; // degrees/s in body frame
     double rollDeg, pitchDeg, yawDeg;    // euler angles, degrees
     Quaternion quaternion;
-    double airspeed; // m/s
-    Vector3f velocity_air_bf; // velocity relative to airmass, body frame
+    double airspeed; // m/s, EAS
+    Vector3f velocity_air_bf; // velocity relative to airmass, body frame, TAS
     double battery_voltage; // Volts
     double battery_current; // Amps
     double battery_remaining; // Ah, if non-zero capacity


### PR DESCRIPTION
@tridge

To fix: SITL temperature compensation encoding error in SIM_MS5611.cpp when temperature < 20C
see autotest: `BaroDrivers `

To investigate: autotest failure in plane of `FenceRetRally` 

To add: incorporate non-standard atmosphere using known ground temperature, pressure, density, or currently measured temperature?

Uses approx. 1.4K less flash
Far lower max. error using functions than table linear interpolation: < 0.6Pa, vs 15-20Pa
